### PR TITLE
Join Item Interaction Fixes

### DIFF
--- a/src/main/java/me/cervinakuy/joineventspro/listener/JoinItems.java
+++ b/src/main/java/me/cervinakuy/joineventspro/listener/JoinItems.java
@@ -93,7 +93,7 @@ public class JoinItems implements Listener {
 
 					if (!itemIdentifier.equals("Enabled")) {
 
-						String pathPrefix = joinType + ".Items" + itemIdentifier;
+						String pathPrefix = joinType + ".Items." + itemIdentifier;
 
 						if (mainHand.getType() == XMaterial.matchXMaterial(joinConfig.getString(pathPrefix + ".Material")).get().parseMaterial()) {
 

--- a/src/main/java/me/cervinakuy/joineventspro/listener/JoinItems.java
+++ b/src/main/java/me/cervinakuy/joineventspro/listener/JoinItems.java
@@ -81,9 +81,9 @@ public class JoinItems implements Listener {
 			
 			if (e.getAction() == Action.RIGHT_CLICK_BLOCK || e.getAction() == Action.RIGHT_CLICK_AIR) {
 
-				ItemStack mainHand = Toolkit.getMainHandItem(p);
+				ItemStack handItem = Toolkit.getHandItemForInteraction(e);
 
-				if (!mainHand.hasItemMeta()) {
+				if (!handItem.hasItemMeta()) {
 					return;
 				}
 
@@ -95,9 +95,9 @@ public class JoinItems implements Listener {
 
 						String pathPrefix = joinType + ".Items." + itemIdentifier;
 
-						if (mainHand.getType() == XMaterial.matchXMaterial(joinConfig.getString(pathPrefix + ".Material")).get().parseMaterial()) {
+						if (handItem.getType() == XMaterial.matchXMaterial(joinConfig.getString(pathPrefix + ".Material")).get().parseMaterial()) {
 
-							if (mainHand.getItemMeta().getDisplayName().equals(joinConfig.getString(pathPrefix + ".Name"))) {
+							if (handItem.getItemMeta().getDisplayName().equals(joinConfig.getString(pathPrefix + ".Name"))) {
 
 								List<String> commands = joinConfig.getStringList(pathPrefix + ".Commands");
 								Toolkit.runCommands(p, commands);

--- a/src/main/java/me/cervinakuy/joineventspro/util/Toolkit.java
+++ b/src/main/java/me/cervinakuy/joineventspro/util/Toolkit.java
@@ -4,6 +4,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 import me.clip.placeholderapi.PlaceholderAPI;
@@ -94,21 +96,16 @@ public class Toolkit {
  	}
 	
  	@SuppressWarnings("deprecation")
-	public static ItemStack getMainHandItem(Player p) {
- 		
- 		if (versionToNumber() == 18) {
- 			
- 			return p.getItemInHand();
- 			
- 		} else if (versionToNumber() > 18) {
- 			
- 			return p.getInventory().getItemInMainHand();
- 			
- 		}
- 		
- 		return p.getItemInHand();
- 		
- 	}
+ 	public static ItemStack getHandItemForInteraction(PlayerInteractEvent e) {
+		Player p = e.getPlayer();
+
+		if (versionToNumber() == 18) {
+			return p.getItemInHand();
+		}
+
+		EquipmentSlot slot = e.getHand() != null ? e.getHand() : EquipmentSlot.HAND;
+		return p.getInventory().getItem(slot);
+	}
 
 	public static String translate(String s) {
 


### PR DESCRIPTION
Resolves PlayerInteractEvent error when right clicking with join items as described in #8.
This will allow the item command logic to execute correctly and also adds support for command execution on off-hand items.